### PR TITLE
fix issue #33 - restore symlinks after containers recreation

### DIFF
--- a/source/entrypoint.sh
+++ b/source/entrypoint.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -e
 
+ensure_freepbx_cli_links() {
+  local cli_name target_path
+
+  for cli_name in fwconsole amportal; do
+    target_path="/var/lib/asterisk/bin/${cli_name}"
+    if [[ -e "$target_path" ]]; then
+      ln -sfn "$target_path" "/usr/sbin/${cli_name}"
+    fi
+  done
+}
+
+ensure_freepbx_cli_links
+
 # Start cron
 /usr/sbin/cron &
 


### PR DESCRIPTION
## Summary

Fixes issue #33  a container recreation issue where the FreePBX CLI symlinks (`/usr/sbin/fwconsole` and `/usr/sbin/amportal`) could be lost after the `freepbx` container was recreated.

This happened because the installation data stored in the mapped volumes was preserved, but the symlinks inside the container filesystem were not. As a result, applying changes from the FreePBX UI could fail after a normal container recreation.

## What changed

- added a small idempotent check in the container entrypoint
- restore `fwconsole` and `amportal` symlinks at startup if their targets already exist in `/var/lib/asterisk/bin`

## Why this approach

This keeps the fix simple and aligned with the current project structure:

- no reinstall is needed after container recreation
- no extra volumes are required
- no change to the existing installation flow
- safe on first boot, because symlinks are only recreated if the installed targets already exist

## Expected result

After FreePBX has been installed once, recreating the `freepbx` container should no longer break the installation due to missing CLI symlinks.

## Notes

Thanks to @djjeck for reporting the issue
