### PR TITLE
hardening: move Fail2ban to optional sidecar service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,9 +43,7 @@ services:
 
   freepbx:
     restart: always
-    image: escomputers/freepbx:17
-    cap_add:
-      - NET_ADMIN
+    image: escomputers/freepbx:17-nofail2ban
     volumes:
       - var_data:/var
       - etc_data:/etc
@@ -60,3 +58,22 @@ services:
       - postfix_sasl_passwd
     depends_on:
       - db
+
+  fail2ban:
+    restart: unless-stopped
+    image: lscr.io/linuxserver/fail2ban:latest
+    container_name: fail2ban
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    environment:
+      PUID: 1000
+      PGID: 2000
+      TZ: UTC
+    volumes:
+      - var_data:/remotelogs/freepbx:ro
+      - ./source/fail2ban/jail.local:/config/fail2ban/jail.local
+      - ./source/fail2ban/filter.d/asterisk.conf:/config/fail2ban/filter.d/asterisk.conf
+    depends_on:
+      - freepbx

--- a/run.sh
+++ b/run.sh
@@ -60,13 +60,14 @@ if [[  "$*" == *"--install-freepbx"*  ]]; then
 
 # CLEAN
 elif [[  "$*" == *"--clean-all"*  ]]; then
-  read -r -p "Are you sure you want to clean up everything? (yes/no)? " confirmation
+  read -r -p "Are you sure you want to clean up everything? Data will be lost. (yes/no)? " confirmation
   if [[ "$confirmation" != "yes" ]]; then
     echo "Cleanup aborted."
     exit 0
   fi
   sudo docker container stop freepbx-docker-db-1 && sudo docker container rm freepbx-docker-db-1
   sudo docker container stop freepbx-docker-freepbx-1 && sudo docker container rm freepbx-docker-freepbx-1
+  sudo docker container stop fail2ban && sudo docker container rm fail2ban
   sudo docker volume rm freepbx-docker_var_data
   sudo docker volume rm freepbx-docker_etc_data
   sudo docker volume rm freepbx-docker_mysql_data

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get -y install \
   libasound2-dev libogg-dev libvorbis-dev libicu-dev libcurl4-openssl-dev \
   odbc-mariadb unixodbc \
   libical-dev libneon27-dev libsrtp2-dev libspandsp-dev libtool-bin \
-  nodejs npm ipset iptables fail2ban php-soap \
+  nodejs npm ipset iptables php-soap \
   postfix libsasl2-modules mailutils \
   certbot python3-certbot-apache logrotate
 
@@ -82,8 +82,6 @@ RUN set -eux \
 
 COPY odbc/odbcinst.ini /etc/odbcinst.ini
 COPY odbc/odbc.ini /etc/odbc.ini
-COPY fail2ban/jail.local /etc/fail2ban/jail.local
-COPY fail2ban/filter.d/asterisk.conf /etc/fail2ban/filter.d/asterisk.conf
 COPY postfix/main.cf /etc/postfix/main.cf
 COPY logrotate/asterisk /etc/logrotate.d/asterisk
 COPY entrypoint.sh entrypoint.sh

--- a/source/entrypoint.sh
+++ b/source/entrypoint.sh
@@ -23,8 +23,4 @@ service postfix start
 # Start Asterisk service
 /usr/local/src/freepbx/start_asterisk start &
 
-# Start Fail2ban
-rm -f /var/run/fail2ban/fail2ban.pid /var/run/fail2ban/fail2ban.sock
-fail2ban-client start &
-
 exec apache2ctl -D FOREGROUND

--- a/source/fail2ban/filter.d/asterisk.conf
+++ b/source/fail2ban/filter.d/asterisk.conf
@@ -1,3 +1,4 @@
+## Version 2025/07/20
 # Fail2Ban filter for asterisk authentication failures
 #
 
@@ -21,13 +22,13 @@ log_prefix= (?:NOTICE|SECURITY|WARNING)%(__pid_re)s:?(?:\[C-[\da-f]*\])?:? [^:]+
 prefregex = ^%(__prefix_line)s%(log_prefix)s <F-CONTENT>.+</F-CONTENT>$
 
 failregex = ^Registration from '[^']*' failed for '<HOST>(:\d+)?' - (?:Wrong password|Username/auth name mismatch|No matching peer found|Not a local domain|Device does not match ACL|Peer is not supposed to register|ACL error \(permit/deny\)|Not a local domain)$
-            ^Call from '[^']*' \(<HOST>:\d+\) to extension '[^']*' rejected because extension not found in context
+            ^Call (?:from '[^']*' )?\((?:(?:TCP|UDP):)?<HOST>:\d+\) to extension '[^']*' rejected because extension not found in context
             ^(?:Host )?<HOST> (?:failed (?:to authenticate\b|MD5 authentication\b)|tried to authenticate with nonexistent user\b)
             ^No registration for peer '[^']*' \(from <HOST>\)$
             ^hacking attempt detected '<HOST>'$
             ^SecurityEvent="(?:FailedACL|InvalidAccountID|ChallengeResponseFailed|InvalidPassword)"(?:(?:,(?!RemoteAddress=)\w+="[^"]*")*|.*?),RemoteAddress="IPV[46]/[^/"]+/<HOST>/\d+"(?:,(?!RemoteAddress=)\w+="[^"]*")*$
             ^"Rejecting unknown SIP connection from <HOST>(?::\d+)?"$
-            ^Request (?:'[^']*' )?from '(?:[^']*|.*?)' failed for '<HOST>(?::\d+)?'\s\(callid: [^\)]*\) - (?:No matching endpoint found|Not match Endpoint(?: Contact)? ACL|(?:Failed|Error) to authenticate)\s*$
+            ^Request (?:'[^']*' )?from '(?:[^']*|.*?)' failed for '<HOST>(?::\d+)?'\s\(callid: [^\)]*\) - (?:No matching endpoint found|Not match Endpoint(?: Contact)? ACL|(?:Failed|Error) to authenticate)\b[^']*$
 
 # FreePBX (todo: make optional in v.0.10):
 #            ^(%(__prefix_line)s|\[\]\s*WARNING%(__pid_re)s:?(?:\[C-[\da-f]*\])? )[^:]+: Friendly Scanner from <HOST>$

--- a/source/fail2ban/jail.local
+++ b/source/fail2ban/jail.local
@@ -1,15 +1,18 @@
-[asterisk]
-ignoreip    = 127.0.0.1/8 ::1
-              10.0.0.0/8
-              172.16.0.0/12
-              192.168.0.0/16
-enabled = true
-backend = auto
-filter = asterisk
-logpath = /var/log/asterisk/full
-maxretry = 2
+[DEFAULT]
+ignoreip = 127.0.0.1/8 ::1
+           10.0.0.0/8
+           172.16.0.0/12
+           192.168.0.0/16
+
+bantime  = 1w
 findtime = 30
-bantime = 1w
-action = iptables-allports[protocol=all]
-[sshd]
-enabled = false
+maxretry = 2
+
+[asterisk]
+enabled  = true
+backend  = auto
+filter   = asterisk
+logpath  = /remotelogs/freepbx/log/asterisk/full
+
+chain    = DOCKER-USER
+action   = iptables-allports[chain=DOCKER-USER, protocol=all]


### PR DESCRIPTION
## Summary

This PR moves Fail2ban out of the FreePBX container and makes it an optional
sidecar service in the Compose stack.

The FreePBX container no longer needs `NET_ADMIN`; that capability is now only
required by the Fail2ban service when users enable Fail2ban-based iptables
enforcement.

## Why

FreePBX/Asterisk do not require `NET_ADMIN` for normal operation.

The previous setup bundled Fail2ban inside the FreePBX image, which forced the
main FreePBX container to receive networking administration privileges even
though those privileges were only needed for Fail2ban.

Splitting Fail2ban into a dedicated service gives a cleaner separation:

- FreePBX container: PBX, web UI, Asterisk, FreePBX framework
- Fail2ban container: optional banning/enforcement component requiring `NET_ADMIN`

## Changes

- Removed Fail2ban from the FreePBX image/runtime
- Removed `NET_ADMIN` from the FreePBX service
- Added optional Fail2ban sidecar service in Docker Compose
- Kept Fail2ban enforcement isolated to the service that actually needs it
- Updated documentation/comments as needed

## Compatibility / migration notes

Users who do not rely on Fail2ban can run the FreePBX container with fewer
capabilities.

Users who want Fail2ban protection must enable/use the new Fail2ban sidecar
service.

New image tag published: escomputers/freepbx:17-nofail2ban